### PR TITLE
Fix footer and empty breadcrumb header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,10 +14,7 @@
 <body>
 <div class="wrapper">
     <section>
-        {% include nav-breadcrumbs.html %}
-
         {{ content }}
-
     </section>
     <footer>
         {% if site.github.is_project_page %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -7,3 +7,7 @@ section {
   width: auto;
   float:none;
 }
+
+footer {
+  position: static;
+}


### PR DESCRIPTION
The header that is supposed to hold the breadcrumbs in is currently useless.

I've also stopped the footer from overlapping, whilst we come up with a better idea.

EDIT: It should be noted I've kept the package in there as it drastically improves SEO.