### PR TITLE
Update where opening brace goes on method declaration

### DIFF
--- a/platforms/web/php/standards.md
+++ b/platforms/web/php/standards.md
@@ -43,7 +43,6 @@ Discussions will be had every other Friday at close of play to discuss/vote on w
 Variable names MUST be defined in camelCase
 
 #### Methods
-Opening braces for methods MUST be on the same line as the declaration, and closing braces MUST go on the next line after the body.
 
 Chained methods MUST be on new lines, and be indented with one tab, as follows:
 


### PR DESCRIPTION
I've just removed the extra definition in our docs as it now matches PSR-2. This was agreed with majority vote in Issues #50 so shouldn't take much to push through.

Closes #50.