### PR TITLE
Fix the iOS link on the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We work with a number of different software platforms. Each has their own set of
 * [💻 General Engineering Practices](general/programming-practices.md)
 * [🌍 Web applications](platforms/web/web.md)
 * 📱 Mobile
-  * [🍎 iOS apps](platforms/mobile/ios.md)
+  * [🍎 iOS apps](platforms/mobile/ios/ios.md)
   * [🤖 Android apps](platforms/mobile/android.md)
   * [📲 React Native](platforms/mobile/react-native/introduction.md)
 * 🖥 Desktop


### PR DESCRIPTION
Quick fix to update the `iOS` link on the main README.md