### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,9 @@
 <!-- Please make sure you use markdown code blocks with the relevant language -->
 <!-- https://help.github.com/articles/creating-and-highlighting-code-blocks -->
 
+### Checklist
+- [ ] I have checked that this is not a duplicate issue.
+
 ### Sources
 <!-- Provide sources of information people can use to research this topic. -->
 <!-- Please try not to be bias towards your point of view and provide counterarguments, if possible. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,6 +11,6 @@
 
 ### Sources
 <!-- Provide sources of information people can use to research this topic. -->
-<!-- Please try not to be bias towards you point of view and provide counterarguments, if possible. -->
+<!-- Please try not to be bias towards your point of view and provide counterarguments, if possible. -->
 
 * [Langley Foxall](https://langleyfoxall.co.uk) - The Langley Foxall website

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+### What you would like to change/add
+<!-- Give a comprehensive description as to what you would like to change -->
+
+### Why you would like to change/add this
+<!-- Explain why you would like to make this change or add to the existing documentation -->
+
+### Examples
+<!-- If this issue needs to include code examples, place them here -->
+<!-- Please make sure you use markdown code blocks with the relevant language -->
+<!-- https://help.github.com/articles/creating-and-highlighting-code-blocks -->
+
+### Sources
+<!-- Provide sources of information people can use to research this topic. -->
+<!-- Please try not to be bias towards you point of view and provide counterarguments, if possible. -->
+
+* [Langley Foxall](https://langleyfoxall.co.uk) - The Langley Foxall website

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds documentation)
+- [ ] Breaking change (This is a significant change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have ensured that I have used relative links where appropriate.
+- [ ] I have proofread my sentences.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have ensured that I have used relative links where appropriate.
-- [ ] I have proofread my sentences.
+- [ ] I have proofread my documentation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] New feature (non-breaking change which adds documentation)
 - [ ] Breaking change (This is a significant change)
 
-## Checklist:
+## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have ensured that I have used relative links where appropriate.


### PR DESCRIPTION
This adds both pull request and issue templates. I think this will introduce more consistency between all our issues and pull requests and standardise topic discussions.

I think we need to add more in the checklist section of the pull request template, but I couldn't come up with any extra ones right now.