### PR TITLE
Fixes #85: Solidify Git Workflow

### DIFF
--- a/devops/git/workflow.md
+++ b/devops/git/workflow.md
@@ -9,7 +9,8 @@ after the initial commit, with the correct protection rules in place.
 
 * `master` should be the working development branch [UNSTABLE]
 * `feature/*` branches created from master for each feature
-* `hotfix/*` branches should only be created off of `staging` or `production` and merged accordingly.
+* `fix/*` branches are for non-urgent fixes, and follow the same flow as feature branches.
+* `hotfix/*` branches should only be created off of `staging` or `production` and merged accordingly for urgent fixes only.
 * `staging` should contain the latest, customer visible changes and be on the `Workshop`
 * `production` should contain stable code on live servers.
 

--- a/devops/git/workflow.md
+++ b/devops/git/workflow.md
@@ -10,7 +10,7 @@ after the initial commit, with the correct protection rules in place.
 * `master` should be the working development branch [UNSTABLE]
 * `feature/*` branches created from master for each feature
 * `fix/*` branches are for non-urgent fixes, and follow the same flow as feature branches.
-* `hotfix/*` branches should only be created off of `staging` or `production` and merged accordingly for urgent fixes only.
+* `hotfix/*` branches should only be created off of `staging` or `production` and merged accordingly for urgent fixes only. However, they can be [cherry picked](https://git-scm.com/docs/git-cherry-pick) into other branches if absolutely necessary.
 * `staging` should contain the latest, customer visible changes and be on the `Workshop`
 * `production` should contain stable code on live servers.
 


### PR DESCRIPTION
## Description
This implements a decision made in Issue #85 to add `fix/*` to our list of branches for non-emergency fixes to existing features.

Closes #85. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds documentation)
- [ ] Breaking change (This is a significant change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have ensured that I have used relative links where appropriate.
- [x] I have proofread my documentation.