### PR TITLE
Document QA branch, fix various minor errors

### DIFF
--- a/devops/git/workflow.md
+++ b/devops/git/workflow.md
@@ -11,7 +11,8 @@ after the initial commit, with the correct protection rules in place.
 * `feature/*` branches created from master for each feature
 * `fix/*` branches are for non-urgent fixes, and follow the same flow as feature branches.
 * `hotfix/*` branches should only be created off of `staging` or `production` and merged accordingly for urgent fixes only. However, they can be [cherry picked](https://git-scm.com/docs/git-cherry-pick) into other branches if absolutely necessary.
-* `staging` should contain the latest, customer visible changes and be on the `Workshop`
+* `qa` should contain the latest, quality assurance (internal testing) visible changes and be on the `Shed` (`qa.project-name.langleyfoxall.app`)
+* `staging` should contain the latest, customer visible changes and be on the `Shed` (`project-name.langleyfoxall.app`)
 * `production` should contain stable code on live servers.
 
 #### Open Source
@@ -43,7 +44,7 @@ Reviewers must directly link to the relevant section of the documentation when r
 re-wording the documentation in their own words.
 
 Only the person who created the pull request or admin should merge it. 
-Even though it may of been accepted by the reviewers the person who created it might of noticed a change after the fact or admins might have a reason for delaying the merge.
+Even though it may of been accepted by the reviewers the person who created it might have noticed a change after the fact or admins might have a reason for delaying the merge.
 
 Developers should avoid bulk changing indentation or spacing, as this can make pull requests more
 difficult to review. It these kind of bulk changes are required, they should ideally be submitted


### PR DESCRIPTION
This PR documents the `qa` branch as part of our Git flow and fixes various minor errors in the Git flow document.