### PR TITLE
Handling expired iOS certs

### DIFF
--- a/platforms/mobile/ios/fastlane/match.md
+++ b/platforms/mobile/ios/fastlane/match.md
@@ -37,6 +37,20 @@ If your project already has a `Matchfile` then Match has already been setup for 
 
 If your project doesn't have a `Matchfile` then you need to init Match for your project, run the command `fastlane match init`, you can then proceed with the commands in the above section.
 
+## Handling Expired Certs
+
+Every year or so the distribution & development certificates will expire as they're valid for a year from the date of creation - as a result of this all provisioning profiles created with those certs will be invalidated.
+
+This means that Match will no longer hold correct certs and profiles, you also won't be able to build the app for testing or push any builds to the appstore. Thankfully this isn't too big of an issue and can be easily resolved with a bit of manual work.
+
+1. Delete all invalid or expired provisoning profiles from the Apple member center, the expired certificate will automatically be deleted by Apple.
+3. Clone down the `apple-certs` repository from the company Github and delete the relevant provisioning profiles for the expired cert in the `profiles` folder (if only development expired only delete all development provisioning profiles etc).
+4. Delete the invalid certificate(s) & key(s) from the `certs` folder.
+5. Push the changes up to Github.
+6. Re-run Match inside of your project directory to recreate the relevant certificate and provisioning profile (`fastlane match appstore` for distribution & `fastlane match development` for development)
+
+That's it - you'll have to re-run match for any project that previously had it's provisioning profile managed by Match.
+
 # Troubleshooting
 - When running the command `fastlane match [option]` I get so far but then I get the following error `An app with that bundle ID needs to exist in order to create a provisioning profile for it` - This is because Match cannot create App IDs on the member center, you'll have to do that manually.
 - I'm having an authention issue when attempting to clone the certificates repo. - Make sure you are authenticated to communicate with Github through ssh (try doing a `git pull` in one of your projects) also make sure you provide Fastlane with the `.git` ssh url when asked.


### PR DESCRIPTION
## Description
This PR adds the steps to follow when iOS certs expire every year.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds documentation)
- [ ] Breaking change (This is a significant change)

## Checklist
- [x] I have ensured that I have used relative links where appropriate.
- [x] I have proofread my documentation.